### PR TITLE
Add dependent libs to shell-stack.nix: gmp and libffi

### DIFF
--- a/shell-stack.nix
+++ b/shell-stack.nix
@@ -6,7 +6,7 @@ with pkgs;
 
 haskell.lib.buildStackProject ({
   name = "stitch-lh";
-  buildInputs = [ git z3 ];
+  buildInputs = [ git z3 gmp libffi ];
   ghc = ghc;
   LANG = "en_US.utf8";
 })


### PR DESCRIPTION
Would not compile on NixOS without these added, would fail with missing .so files.

The messages were akin to:

```
setenv                           > configure
setenv                           > /home/fizzixnerd/.stack/setup-exe-cache/x86_64-linux-nix/Cabal-simple_mPHDZzAJ_3.2.0.0_ghc-8.10.2: error while loading shared libraries: libffi.so.7: cannot open shared object file: No such file or directory
```